### PR TITLE
feat: add docker-compose for setting up bot services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+POSTGRES_USER=your_postgres_user
+POSTGRES_PASSWORD=your_postgres_password
+POSTGRES_DB=your_database_name
+VALKEY_PASSWORD=your_valkey_password

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 drizzle/
 .vscode/
 config.json
+.env
 .yarn

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 node_modules/
 drizzle/
 .vscode/
+initdb/
 config.json
 .env
 .yarn

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ target/
 node_modules/
 drizzle/
 .vscode/
-initdb/
 config.json
 .env
 .yarn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./initdb:/docker-entrypoint-initdb.d
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+
+  valkey:
+    image: valkey/valkey:8-alpine
+    container_name: valkey
+    restart: always
+    command: ["valkey-server", "--requirepass", "${VALKEY_PASSWORD}"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - valkey_data:/data
+    healthcheck:
+      test: ["CMD", "valkey-cli", "-a", "${VALKEY_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+
+volumes:
+  postgres_data:
+  valkey_data:
+
+networks:
+  backend:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./initdb:/docker-entrypoint-initdb.d
     ports:
       - "5432:5432"
     healthcheck:


### PR DESCRIPTION
This pull request introduces a PostgreSQL and Valkey setup using Docker Compose, along with corresponding environment variable configurations. The changes aim to simplify local development by containerizing these services and providing an example `.env` file for configuration.

### Environment Configuration:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R4): Added environment variables for PostgreSQL (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`) and Valkey (`VALKEY_PASSWORD`) to facilitate local setup.

### Docker Compose Setup:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R46): Added a `postgres` service with PostgreSQL 17 Alpine image, environment variables, volume mappings, health checks, and network configuration.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R46): Added a `valkey` service with Valkey 8 Alpine image, command configuration, volume mappings, health checks, and network configuration.