### PR TITLE
chore: modified code to use self-signed ssl certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 node_modules/
 drizzle/
 .vscode/
+certs/
 config.json
 .env
 .yarn

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,8 @@ drizzle/
 .vscode/
 .github/
 .yarn/
+docs/
+certs/
 config.json
 config.example.json
 package.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,18 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
+      - ./certs/psql-server.crt:/var/lib/postgresql/server.crt:ro
+      - ./certs/psql-server.key:/var/lib/postgresql/server.key:ro
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - '5432:5432'
+    command: >
+      postgres
+      -c ssl=on
+      -c ssl_cert_file=/var/lib/postgresql/server.crt
+      -c ssl_key_file=/var/lib/postgresql/server.key
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER}']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -23,13 +30,23 @@ services:
     image: valkey/valkey:8-alpine
     container_name: valkey
     restart: always
-    command: ["valkey-server", "--requirepass", "${VALKEY_PASSWORD}"]
     ports:
-      - "6379:6379"
+      - '6379:6379'
     volumes:
+      - ./certs/cache-server.crt:/certs/server.crt:ro
+      - ./certs/cache-server.key:/certs/server.key:ro
+      - ./certs/cache-ca.crt:/certs/ca.crt:ro
       - valkey_data:/data
+    command: >
+      valkey-server
+      --requirepass ${VALKEY_PASSWORD}
+      --tls-port 6379
+      --port 0
+      --tls-cert-file /certs/server.crt
+      --tls-key-file /certs/server.key
+      --tls-ca-cert-file /certs/ca.crt
     healthcheck:
-      test: ["CMD", "valkey-cli", "-a", "${VALKEY_PASSWORD}", "ping"]
+      test: ['CMD', 'valkey-cli', '-a', '${VALKEY_PASSWORD}', 'ping']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -11,10 +11,20 @@ export default defineConfig({
   dialect: 'postgresql',
   dbCredentials: {
     url: database.dbConnectionString,
-    ssl: {
-      ca: fs.readFileSync(path.resolve('./certs/psql-ca.crt')),
-      cert: fs.readFileSync(path.resolve('./certs/psql-server.crt')),
-      key: fs.readFileSync(path.resolve('./certs/psql-client.key')),
-    },
+    ssl: (() => {
+      try {
+        return {
+          ca: fs.readFileSync(path.resolve('./certs/psql-ca.crt')),
+          key: fs.readFileSync(path.resolve('./certs/psql-client.key')),
+          cert: fs.readFileSync(path.resolve('./certs/psql-server.crt')),
+        };
+      } catch (error) {
+        console.warn(
+          'Failed to load certificates for database, using insecure connection:',
+          error,
+        );
+        return undefined;
+      }
+    })(),
   },
 });

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { defineConfig } from 'drizzle-kit';
 
 const config = JSON.parse(fs.readFileSync('./config.json', 'utf8'));
@@ -10,5 +11,10 @@ export default defineConfig({
   dialect: 'postgresql',
   dbCredentials: {
     url: database.dbConnectionString,
+    ssl: {
+      ca: fs.readFileSync(path.resolve('./certs/psql-ca.crt')),
+      cert: fs.readFileSync(path.resolve('./certs/psql-server.crt')),
+      key: fs.readFileSync(path.resolve('./certs/psql-client.key')),
+    },
   },
 });

--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Get the Effective User ID
+_uid="$(id -u)"
+
+# Create the certificates directory
+mkdir -p certs
+
+# Generate PostgreSQL Certificates
+openssl req -new -x509 -days 365 -nodes \
+  -out certs/psql-server.crt \
+  -keyout certs/psql-server.key \
+  -subj "/CN=localhost"
+
+# Generate Valkey Certificates
+openssl req -new -x509 -days 365 -nodes \
+  -out certs/cache-server.crt \
+  -keyout certs/cache-server.key \
+  -subj "/CN=localhost"
+
+# Get CA Certificates
+cp certs/psql-server.crt certs/psql-ca.crt
+cp certs/cache-server.crt certs/cache-ca.crt
+
+# Setup Permissions
+chmod 0600 certs/psql-server.key
+chmod 0600 certs/cache-server.key
+
+# Assign Ownership
+sudo chown 70:70 certs/psql-*.*
+sudo chown 999:1000 certs/cache-*.*
+
+# Get Client Keys
+sudo cp certs/psql-server.key certs/psql-client.key
+sudo cp certs/cache-server.key certs/cache-client.key
+
+# Change Client Key Ownership
+sudo chown $_uid:$_uid certs/psql-client.key
+sudo chown $_uid:$_uid certs/cache-client.key
+
+# Change Client Key Permissions
+sudo chmod +r certs/psql-client.key
+sudo chmod +r certs/cache-client.key

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -100,11 +100,21 @@ export async function initializeDatabaseConnection(): Promise<boolean> {
     // Create new connection pool
     dbPool = new Pool({
       connectionString: config.database.dbConnectionString,
-      ssl: {
-        ca: fs.readFileSync(path.resolve('./certs/psql-ca.crt')),
-        cert: fs.readFileSync(path.resolve('./certs/psql-server.crt')),
-        key: fs.readFileSync(path.resolve('./certs/psql-client.key')),
-      },
+      ssl: (() => {
+        try {
+          return {
+            ca: fs.readFileSync(path.resolve('./certs/psql-ca.crt')),
+            key: fs.readFileSync(path.resolve('./certs/psql-client.key')),
+            cert: fs.readFileSync(path.resolve('./certs/psql-server.crt')),
+          };
+        } catch (error) {
+          console.warn(
+            'Failed to load certificates for database, using insecure connection:',
+            error,
+          );
+          return undefined;
+        }
+      })(),
       connectionTimeoutMillis: 10000,
     });
 

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -1,6 +1,8 @@
 // ========================
 // External Imports
 // ========================
+import fs from 'node:fs';
+import path from 'node:path';
 import pkg from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Client } from 'discord.js';
@@ -98,7 +100,11 @@ export async function initializeDatabaseConnection(): Promise<boolean> {
     // Create new connection pool
     dbPool = new Pool({
       connectionString: config.database.dbConnectionString,
-      ssl: true,
+      ssl: {
+        ca: fs.readFileSync(path.resolve('./certs/psql-ca.crt')),
+        cert: fs.readFileSync(path.resolve('./certs/psql-server.crt')),
+        key: fs.readFileSync(path.resolve('./certs/psql-client.key')),
+      },
       connectionTimeoutMillis: 10000,
     });
 

--- a/src/db/redis.ts
+++ b/src/db/redis.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import Redis from 'ioredis';
 import { Client } from 'discord.js';
 
@@ -91,6 +93,11 @@ async function initializeRedisConnection() {
       },
       maxRetriesPerRequest: 3,
       enableOfflineQueue: true,
+      tls: {
+        ca: fs.readFileSync(path.resolve('./certs/cache-ca.crt')),
+        cert: fs.readFileSync(path.resolve('./certs/cache-server.crt')),
+        key: fs.readFileSync(path.resolve('./certs/cache-client.key')),
+      },
     });
 
     // ========================

--- a/src/db/redis.ts
+++ b/src/db/redis.ts
@@ -93,11 +93,21 @@ async function initializeRedisConnection() {
       },
       maxRetriesPerRequest: 3,
       enableOfflineQueue: true,
-      tls: {
-        ca: fs.readFileSync(path.resolve('./certs/cache-ca.crt')),
-        cert: fs.readFileSync(path.resolve('./certs/cache-server.crt')),
-        key: fs.readFileSync(path.resolve('./certs/cache-client.key')),
-      },
+      tls: (() => {
+        try {
+          return {
+            ca: fs.readFileSync(path.resolve('./certs/cache-ca.crt')),
+            key: fs.readFileSync(path.resolve('./certs/cache-client.key')),
+            cert: fs.readFileSync(path.resolve('./certs/cache-server.crt')),
+          };
+        } catch (error) {
+          console.warn(
+            'Failed to load certificates for cache, using insecure connection:',
+            error,
+          );
+          return undefined;
+        }
+      })(),
     });
 
     // ========================

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,5 +1,6 @@
 import Canvas from '@napi-rs/canvas';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import {
   AttachmentBuilder,


### PR DESCRIPTION
This pull request introduces SSL/TLS support for both the PostgreSQL database and the Redis cache, along with associated configuration and certificate generation scripts. It also includes updates to ensure secure connections and proper error handling when SSL/TLS certificates are unavailable.

### SSL/TLS Implementation for Database and Cache

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R11-R22): Configured PostgreSQL and Redis containers to use SSL/TLS by mounting certificate files and updating startup commands. Added healthcheck updates for consistency. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R11-R22) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L26-R49)
* [`drizzle.config.ts`](diffhunk://#diff-d4e1c765f5d43acb9c59d87b520418289031da3fe52f5031041502b1250509c8R14-R28): Updated database configuration to include SSL options with error handling for missing certificates.
* [`src/db/db.ts`](diffhunk://#diff-edc834adbf0274511449786b6f3cf185c31f47eeccbe158e8377f772d7614c61L101-R117): Modified the database connection pool to use SSL certificates with fallback to insecure connections if certificates are unavailable.
* [`src/db/redis.ts`](diffhunk://#diff-b3fb3296853268d7c38744daaecc2753275d67e8ee1687cec394d1a3506aba54R96-R110): Updated Redis connection to include TLS options with error handling for missing certificates.

### Certificate Management

* [`generate-certs.sh`](diffhunk://#diff-af99dcece3220e32558ceca1c10ab81cdde0e21bb14f81904d6ed73efaf1f292R1-R43): Added a script to generate and manage SSL/TLS certificates for both PostgreSQL and Redis, including setting appropriate permissions and ownership.

### Minor Updates

* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R7-R8): Added `docs/` and `certs/` directories to the ignore list.
* General imports: Added `fs` and `path` imports in several files to handle file system operations for SSL/TLS certificates. [[1]](diffhunk://#diff-d4e1c765f5d43acb9c59d87b520418289031da3fe52f5031041502b1250509c8R2) [[2]](diffhunk://#diff-edc834adbf0274511449786b6f3cf185c31f47eeccbe158e8377f772d7614c61R4-R5) [[3]](diffhunk://#diff-b3fb3296853268d7c38744daaecc2753275d67e8ee1687cec394d1a3506aba54R1-R2) [[4]](diffhunk://#diff-98a78ebd51b441b04fbc66b69ba164b878fff0eca351bb7171a525e499a3d91cL2-R3)