### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-build-and-compile.yml
+++ b/.github/workflows/npm-build-and-compile.yml
@@ -2,7 +2,7 @@ name: NodeJS Build and Compile
 
 permissions:
   contents: read
-
+  actions: write
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/npm-build-and-compile.yml
+++ b/.github/workflows/npm-build-and-compile.yml
@@ -1,5 +1,8 @@
 name: NodeJS Build and Compile
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/ahmadk953/poixpixel-discord-bot/security/code-scanning/13](https://github.com/ahmadk953/poixpixel-discord-bot/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
