### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,6 +2,9 @@ name: Commitlint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     name: Run commitlint scanning


### PR DESCRIPTION
Potential fix for [https://github.com/ahmadk953/poixpixel-discord-bot/security/code-scanning/12](https://github.com/ahmadk953/poixpixel-discord-bot/security/code-scanning/12)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., for checking out the code and validating commits), we will set `contents: read` as the minimal required permission. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
