### PR TITLE
ci: add release workflow and automatic changelog generation

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [23.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -35,8 +35,8 @@ jobs:
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
-        run: npx commitlint --last --verbose
+        run: yarn dlx commitlint --last --verbose
 
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: yarn dlx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,10 +1,4 @@
-# Dependency Review Action
-#
-# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
-#
-# Source repository: https://github.com/actions/dependency-review-action
-# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
-name: 'Dependency Review'
+name: Dependency Review
 on: [pull_request]
 
 permissions:
@@ -14,7 +8,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout Repository'
+      - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: 'Dependency Review'
+      - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -16,6 +16,9 @@ jobs:
       contents: read
       security-events: write
       actions: read
+    strategy:
+      matrix:
+        node-version: [24.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,11 +26,17 @@ jobs:
       - name: Configure Corepack
         run: corepack enable
 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
       - name: Install Dependencies
         run: yarn install
 
       - name: Run ESLint
-        run: npx eslint ./src
+        run: yarn dlx eslint ./src
           --config eslint.config.mjs
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif

--- a/.github/workflows/npm-build-and-compile.yml
+++ b/.github/workflows/npm-build-and-compile.yml
@@ -1,4 +1,4 @@
-name: NodeJS Build and Compile
+name: NodeJS Build
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [23.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - run: yarn dlx changelogithub
+      - name: Generate Changelog
+        run: yarn dlx changelogithub
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Automatic Release Changelog
+name: Generate Changelog
 
 permissions:
   contents: write
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 jobs:
   release:
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [23.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - run: npx changelogithub
+      - run: yarn dlx changelogithub
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Automatic Release Changelog
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [23.x]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Corepack
+        run: corepack enable
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - run: npx changelogithub
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -50,5 +50,5 @@
     "typescript": "^5.8.3",
     "typescript-transform-paths": "^3.5.5"
   },
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "yarn@4.9.2"
 }


### PR DESCRIPTION
This pull request introduces an automated workflow for generating release changelogs and updates the package manager version in `package.json`. Below are the key changes:

### Workflow Automation:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R35): Added a new GitHub Actions workflow to automatically generate release changelogs when a tag matching the pattern `v*` is pushed. The workflow uses Node.js 23.x, Corepack, and the `changelogithub` tool to create the changelogs.

### Dependency Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L53-R53): Updated the Yarn package manager version from `4.9.1` to `4.9.2`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a GitHub Actions workflow to automatically generate changelogs on release tags and updated Yarn to version 4.9.2.

- **Dependencies**
  - Updated Yarn version in package.json.

<!-- End of auto-generated description by cubic. -->

