### PR TITLE
fix(bot): added default values for leveling system

### DIFF
--- a/src/db/functions/levelFunctions.ts
+++ b/src/db/functions/levelFunctions.ts
@@ -86,8 +86,8 @@ export async function addXpToUser(
     const cacheKey = `level-${discordId}`;
     const userData = await getUserLevel(discordId);
     const currentLevel = userData.level;
-    const currentXp = Number(userData.xp);
-    const xpToAdd = Number(amount);
+    const currentXp = userData.xp;
+    const xpToAdd = amount;
 
     userData.xp = currentXp + xpToAdd;
 

--- a/src/db/functions/levelFunctions.ts
+++ b/src/db/functions/levelFunctions.ts
@@ -86,10 +86,8 @@ export async function addXpToUser(
     const cacheKey = `level-${discordId}`;
     const userData = await getUserLevel(discordId);
     const currentLevel = userData.level;
-    const currentXp = userData.xp;
-    const xpToAdd = amount;
 
-    userData.xp = currentXp + xpToAdd;
+    userData.xp = Number(userData.xp ?? 0) + Number(amount);
 
     userData.lastMessageTimestamp = new Date();
     userData.level = calculateLevelFromXp(userData.xp);

--- a/src/util/levelingSystem.ts
+++ b/src/util/levelingSystem.ts
@@ -20,11 +20,19 @@ let minXpOffered = config.leveling.minXpAwarded ?? 5;
 let maxXpOffered = config.leveling.maxXpAwarded ?? 15;
 
 if (typeof minXpOffered === 'string') {
-  minXpOffered = parseInt(minXpOffered, 10);
+  minXpOffered = Number(minXpOffered);
 }
+if (isNaN(minXpOffered) || minXpOffered < 0) {
+  throw new Error('Minimum XP awarded must be a non-negative number.');
+}
+
 if (typeof maxXpOffered === 'string') {
-  maxXpOffered = parseInt(maxXpOffered, 10);
+  maxXpOffered = Number(maxXpOffered);
 }
+if (isNaN(maxXpOffered) || maxXpOffered < 0) {
+  throw new Error('Maximum XP awarded must be a non-negative number.');
+}
+
 if (minXpOffered > maxXpOffered) {
   throw new Error(
     'Minimum XP awarded must be less than or equal to maximum XP awarded.',
@@ -36,11 +44,12 @@ const MAX_XP = maxXpOffered;
 
 let xpCooldownValue = config.leveling.xpCooldown ?? 60;
 if (typeof xpCooldownValue === 'string') {
-  xpCooldownValue = parseInt(xpCooldownValue, 10);
+  xpCooldownValue = Number(xpCooldownValue);
 }
-if (isNaN(xpCooldownValue)) {
-  throw new Error('XP cooldown must be a number.');
+if (isNaN(xpCooldownValue) || xpCooldownValue < 0) {
+  throw new Error('XP cooldown must be a non-negative number.');
 }
+
 const XP_COOLDOWN = xpCooldownValue * 1000;
 
 const __dirname = path.resolve();

--- a/src/util/levelingSystem.ts
+++ b/src/util/levelingSystem.ts
@@ -16,9 +16,9 @@ import { processMessageAchievements } from './achievementManager.js';
 
 const config = loadConfig();
 
-const XP_COOLDOWN = config.leveling.xpCooldown * 1000;
-const MIN_XP = config.leveling.minXpAwarded;
-const MAX_XP = config.leveling.maxXpAwarded;
+const XP_COOLDOWN = config.leveling.xpCooldown || 60 * 1000;
+const MIN_XP = config.leveling.minXpAwarded || 5;
+const MAX_XP = config.leveling.maxXpAwarded || 15;
 
 const __dirname = path.resolve();
 

--- a/src/util/levelingSystem.ts
+++ b/src/util/levelingSystem.ts
@@ -46,7 +46,7 @@ let xpCooldownValue = config.leveling.xpCooldown ?? 60;
 if (typeof xpCooldownValue === 'string') {
   xpCooldownValue = Number(xpCooldownValue);
 }
-if (isNaN(xpCooldownValue) || xpCooldownValue < 0) {
+if (!Number.isFinite(xpCooldownValue) || xpCooldownValue < 0) {
   throw new Error('XP cooldown must be a non-negative number.');
 }
 

--- a/src/util/levelingSystem.ts
+++ b/src/util/levelingSystem.ts
@@ -16,9 +16,32 @@ import { processMessageAchievements } from './achievementManager.js';
 
 const config = loadConfig();
 
-const XP_COOLDOWN = config.leveling.xpCooldown || 60 * 1000;
-const MIN_XP = config.leveling.minXpAwarded || 5;
-const MAX_XP = config.leveling.maxXpAwarded || 15;
+let minXpOffered = config.leveling.minXpAwarded ?? 5;
+let maxXpOffered = config.leveling.maxXpAwarded ?? 15;
+
+if (typeof minXpOffered === 'string') {
+  minXpOffered = parseInt(minXpOffered, 10);
+}
+if (typeof maxXpOffered === 'string') {
+  maxXpOffered = parseInt(maxXpOffered, 10);
+}
+if (minXpOffered > maxXpOffered) {
+  throw new Error(
+    'Minimum XP awarded must be less than or equal to maximum XP awarded.',
+  );
+}
+
+const MIN_XP = minXpOffered;
+const MAX_XP = maxXpOffered;
+
+let xpCooldownValue = config.leveling.xpCooldown ?? 60;
+if (typeof xpCooldownValue === 'string') {
+  xpCooldownValue = parseInt(xpCooldownValue, 10);
+}
+if (isNaN(xpCooldownValue)) {
+  throw new Error('XP cooldown must be a number.');
+}
+const XP_COOLDOWN = xpCooldownValue * 1000;
 
 const __dirname = path.resolve();
 


### PR DESCRIPTION
This pull request includes updates to the leveling system to improve type handling, validation, and simplify the logic for XP calculations. The changes ensure better error handling and remove unnecessary type conversions.

### Improvements to type handling and validation:

* [`src/db/functions/levelFunctions.ts`](diffhunk://#diff-8d48f385dd0099758a51bdaa671da2cd409fe4d8fdaf1506aa7f1353780243daL89-R90): Removed unnecessary `Number` conversions for `currentXp` and `xpToAdd`, as the values are now directly used in their expected types.
* [`src/util/levelingSystem.ts`](diffhunk://#diff-1970aad4c9a4814f5fac171d1da23ad037ea24d02af9a76a6ea65d390a653d32L19-R44): Added validation to ensure `minXpOffered` is less than or equal to `maxXpOffered` and that `xpCooldownValue` is a valid number. Default values and fallback parsing logic were introduced to handle cases where configuration values are strings or undefined.