### PR TITLE
feat(bot/commands): added purge command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 drizzle/
 .vscode/
 certs/
+temp/
+.serena/
 config.json
 .env
 .yarn

--- a/docs/bot/commands/purge-command.md
+++ b/docs/bot/commands/purge-command.md
@@ -45,7 +45,7 @@ The `/purge` command allows moderators to bulk delete messages in a Discord chan
   - Reason for purging
 - Uploads the log file to the configured audit log channel
 - Automatically deletes the temporary log file after upload
-- **Separated into dedicated utility module** (`purgeLogger.ts`)
+- **Logging handled in** `logAction.ts` (purge case)
 
 ### 3. **Safety Features**
 
@@ -92,7 +92,7 @@ The `/purge` command allows moderators to bulk delete messages in a Discord chan
 
 5. **Bulk Delete**: Uses Discord's bulk delete API with the `filterOld` parameter to remove all eligible messages in one operation.
 
-6. **Audit Logging**: Calls the `logPurgeAction()` utility function which:
+6. **Audit Logging**: Uses the `logAction()` utility (purge branch) which:
    - Creates a detailed log file with all deleted message information
    - Uploads the log file to the configured audit log channel
    - Creates an embed with summary information
@@ -153,22 +153,14 @@ The command uses the following configuration from `config.json`:
 ## File Location
 
 **Command**: `src/commands/moderation/purge.ts`
-**Audit Logger**: `src/util/logging/purgeLogger.ts`
+**Audit Logger**: `src/util/logging/logAction.ts`
 **Compiled Command**: `target/commands/moderation/purge.js`
-**Compiled Logger**: `target/util/logging/purgeLogger.js`
-
-## Related Commands
-
-- `/ban` - Ban a member from the server
-- `/kick` - Kick a member from the server
-- `/mute` - Mute a member
-- `/warn` - Warn a member
+**Compiled Logger**: `target/util/logging/logAction.js`
 
 ## Notes
 
 - The command responds with an ephemeral message (only visible to the moderator)
 - The log file is temporarily stored in the `temp/` directory
 - All operations are logged for transparency and accountability
-- Achievement progress is tracked when using this command
-- The default age limit is now **14 days** (increased from 7 days)
+- The default age limit is **14 days**
 - Users can specify custom age limits up to 14 days using format like: `7d`, `12h`, `3d`, etc.

--- a/docs/bot/commands/purge-command.md
+++ b/docs/bot/commands/purge-command.md
@@ -1,0 +1,174 @@
+# Purge Command
+
+## Overview
+
+The `/purge` command allows moderators to bulk delete messages in a Discord channel. This is useful for cleaning up spam, removing off-topic conversations, or managing channel content.
+
+## Command Details
+
+### Permissions Required
+
+- **User**: `MANAGE_MESSAGES` permission
+- **Bot**: `MANAGE_MESSAGES` and `READ_MESSAGE_HISTORY` permissions
+
+### Command Syntax
+
+```bash
+/purge amount:<1-100> [age_limit:<duration>] [user:<@user>] [reason:<text>]
+```
+
+### Parameters
+
+| Parameter   | Type    | Required | Description                                               |
+| ----------- | ------- | -------- | --------------------------------------------------------- |
+| `amount`    | Integer | ✅ Yes   | Number of messages to delete (1-100)                      |
+| `age_limit` | String  | ❌ No    | Delete messages newer than this (e.g., 7d, 14d, max: 14d) |
+| `user`      | User    | ❌ No    | Only delete messages from this specific user              |
+| `reason`    | String  | ❌ No    | Reason for purging messages (for audit log)               |
+
+## Features
+
+### 1. **Bulk Message Deletion**
+
+- Deletes up to 100 messages at a time
+- Can filter messages by a specific user
+- **Configurable age limit** (default: 14 days, max: 14 days per Discord API)
+- Automatically filters out messages older than the specified limit
+
+### 2. **Detailed Audit Logging**
+
+- Creates a comprehensive log file containing:
+  - Message ID, author, timestamp
+  - Message content (including attachments and embeds)
+  - Channel information
+  - Moderator information
+  - Reason for purging
+- Uploads the log file to the configured audit log channel
+- Automatically deletes the temporary log file after upload
+- **Separated into dedicated utility module** (`purgeLogger.ts`)
+
+### 3. **Safety Features**
+
+- Only works in guild text channels (not DMs)
+- Validates bot permissions before executing
+- Reports how many messages were skipped due to age restrictions
+- Provides detailed error messages for failures
+
+## Usage Examples
+
+### Example 1: Delete Last 50 Messages (Default 14d Limit)
+
+```bash
+/purge amount:50 reason:Cleaning up spam
+```
+
+### Example 2: Delete Messages from Specific User with 7d Limit
+
+```bash
+/purge amount:30 age_limit:7d user:@SpamBot reason:Bot spam cleanup
+```
+
+### Example 3: Delete Last 10 Messages with Custom Age Limit
+
+```bash
+/purge amount:10 age_limit:3d reason:Recent off-topic cleanup
+```
+
+### Example 4: Quick Cleanup with Maximum Age Limit
+
+```bash
+/purge amount:100 age_limit:14d
+```
+
+## How It Works
+
+1. **Validation**: The bot checks if the command is used in a valid guild text channel and verifies permissions.
+
+2. **Age Limit Parsing**: Parses the optional `age_limit` parameter using the `parseDuration()` helper. If not specified, defaults to 14 days. Validates that the limit doesn't exceed Discord's 14-day maximum.
+
+3. **Message Fetching**: Retrieves up to 100 messages from the channel. If a user is specified, it filters only their messages.
+
+4. **Age Filtering**: Messages older than the specified age limit are automatically excluded.
+
+5. **Bulk Delete**: Uses Discord's bulk delete API with the `filterOld` parameter to remove all eligible messages in one operation.
+
+6. **Audit Logging**: Calls the `logPurgeAction()` utility function which:
+   - Creates a detailed log file with all deleted message information
+   - Uploads the log file to the configured audit log channel
+   - Creates an embed with summary information
+   - Cleans up the temporary file
+
+7. **Achievement Tracking**: Records the command usage for achievement progress.
+
+## Limitations
+
+### Discord API Limitations
+
+- **Maximum messages per operation**: 100
+- **Message age limit**: Cannot delete messages older than 14 days
+- **Rate limits**: Discord may rate-limit bulk delete operations if used excessively
+
+### Bot Limitations
+
+- Messages older than the specified age limit (default 14d) are automatically skipped
+- Requires specific bot permissions in the channel
+- Cannot delete pinned messages (Discord API behavior)
+
+## Audit Log Format
+
+The audit log embed includes:
+
+- 🗑️ **Title**: "PURGE"
+- **Channel**: Which channel was purged
+- **Moderator**: Who executed the command
+- **Messages Deleted**: Number of successfully deleted messages
+- **Target User**: If filtering by user, shows the target
+- **Messages Skipped**: Count of messages that were too old (with age limit)
+- **Reason**: The provided reason for the purge
+- **Timestamp**: When the purge was executed
+- **Attached File**: Complete log of all deleted messages
+
+## Error Handling
+
+The command handles various error scenarios:
+
+| Error                     | Response                                                                   |
+| ------------------------- | -------------------------------------------------------------------------- |
+| Wrong channel type        | "This command can only be used in guild text channels."                    |
+| Missing bot permissions   | "I do not have permission to manage messages..."                           |
+| No messages found         | "No messages found to delete." or user-specific message                    |
+| All messages too old      | "All selected messages are older than [age_limit] and cannot be deleted."  |
+| Invalid age limit format  | "Invalid age limit format. Please use format like: 7d, 14d, 12h, etc."    |
+| Age limit exceeds maximum | "⚠️ Age limit cannot exceed 14 days (Discord API limitation)..."          |
+| Fetch failure             | "Failed to fetch messages from this channel."                              |
+| Delete failure            | "Failed to delete messages. Please try again."                             |
+| Generic error             | "An error occurred while purging messages."                                |
+
+## Configuration
+
+The command uses the following configuration from `config.json`:
+
+- `channels.logs`: The channel ID where audit logs are sent
+
+## File Location
+
+**Command**: `src/commands/moderation/purge.ts`
+**Audit Logger**: `src/util/logging/purgeLogger.ts`
+**Compiled Command**: `target/commands/moderation/purge.js`
+**Compiled Logger**: `target/util/logging/purgeLogger.js`
+
+## Related Commands
+
+- `/ban` - Ban a member from the server
+- `/kick` - Kick a member from the server
+- `/mute` - Mute a member
+- `/warn` - Warn a member
+
+## Notes
+
+- The command responds with an ephemeral message (only visible to the moderator)
+- The log file is temporarily stored in the `temp/` directory
+- All operations are logged for transparency and accountability
+- Achievement progress is tracked when using this command
+- The default age limit is now **14 days** (increased from 7 days)
+- Users can specify custom age limits up to 14 days using format like: `7d`, `12h`, `3d`, etc.

--- a/src/commands/moderation/purge.ts
+++ b/src/commands/moderation/purge.ts
@@ -1,0 +1,248 @@
+import {
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+  type GuildTextBasedChannel,
+  type Message,
+} from 'discord.js';
+
+import type { OptionsCommand } from '@/types/CommandTypes.js';
+import { logger } from '@/util/logger.js';
+import { processCommandAchievements } from '@/util/achievementManager.js';
+import {
+  parseDuration,
+  validateInteraction,
+  safelyRespond,
+} from '@/util/helpers.js';
+import logAction from '@/util/logging/logAction.js';
+import type { PurgeLogAction } from '@/util/logging/types.js';
+
+const command: OptionsCommand = {
+  data: new SlashCommandBuilder()
+    .setName('purge')
+    .setDescription('Bulk delete messages in this channel')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+    .addIntegerOption((option) =>
+      option
+        .setName('amount')
+        .setDescription('Number of messages to delete (1-100)')
+        .setRequired(true)
+        .setMinValue(1)
+        .setMaxValue(100),
+    )
+    .addStringOption((option) =>
+      option
+        .setName('age_limit')
+        .setDescription(
+          'Delete messages newer than this (e.g., 7d, 14d, max: 14d)',
+        )
+        .setRequired(false),
+    )
+    .addUserOption((option) =>
+      option
+        .setName('user')
+        .setDescription('Only delete messages from this user')
+        .setRequired(false),
+    )
+    .addStringOption((option) =>
+      option
+        .setName('reason')
+        .setDescription('Reason for purging messages')
+        .setRequired(false),
+    ),
+  execute: async (interaction) => {
+    if (!interaction.isChatInputCommand() || !interaction.guild) return;
+
+    if (!(await validateInteraction(interaction))) return;
+
+    await interaction.deferReply({ flags: ['Ephemeral'] });
+
+    try {
+      const { guild, channel } = interaction;
+      const amount = interaction.options.getInteger('amount', true);
+      const targetUser = interaction.options.getUser('user');
+      const ageLimitInput = interaction.options.getString('age_limit');
+      const reason =
+        interaction.options.getString('reason') ?? 'No reason provided';
+      const moderator = await guild.members.fetch(interaction.user.id);
+
+      // Parse age limit (default to 14 days, max 14 days per Discord API)
+      let ageLimitMs: number;
+      let ageLimitStr: string;
+
+      if (ageLimitInput) {
+        try {
+          ageLimitMs = parseDuration(ageLimitInput);
+          ageLimitStr = ageLimitInput;
+
+          // Discord API limitation: messages older than 14 days cannot be bulk deleted
+          const maxAgeMs = 14 * 24 * 60 * 60 * 1000;
+          if (ageLimitMs > maxAgeMs) {
+            await safelyRespond(
+              interaction,
+              '⚠️ Age limit cannot exceed 14 days (Discord API limitation). Using 14 days instead.',
+            );
+            ageLimitMs = maxAgeMs;
+            ageLimitStr = '14d';
+          }
+        } catch (_error) {
+          await safelyRespond(
+            interaction,
+            'Invalid age limit format. Please use format like: 7d, 14d, 12h, etc.',
+          );
+          return;
+        }
+      } else {
+        // Default to 14 days
+        ageLimitMs = 14 * 24 * 60 * 60 * 1000;
+        ageLimitStr = '14d';
+      }
+
+      // Validate channel type
+      if (
+        !channel?.isTextBased() ||
+        channel.isDMBased() ||
+        !('name' in channel)
+      ) {
+        await safelyRespond(
+          interaction,
+          'This command can only be used in guild text channels.',
+        );
+        return;
+      }
+
+      // Type guard: after this point, channel is a guild text-based channel
+      const guildChannel = channel as GuildTextBasedChannel;
+
+      // Check bot permissions
+      const botMember = await guild.members.fetch(interaction.client.user.id);
+      const channelPermissions = guildChannel.permissionsFor(botMember);
+
+      if (
+        !channelPermissions?.has(PermissionFlagsBits.ManageMessages) ||
+        !channelPermissions?.has(PermissionFlagsBits.ReadMessageHistory)
+      ) {
+        await safelyRespond(
+          interaction,
+          'I do not have permission to manage messages or read message history in this channel.',
+        );
+        return;
+      }
+
+      // Fetch messages
+      let messagesToDelete: Message[] = [];
+      try {
+        const fetchedMessages = await guildChannel.messages.fetch({
+          limit: 100,
+        });
+
+        if (targetUser) {
+          // Filter by user
+          messagesToDelete = Array.from(fetchedMessages.values())
+            .filter((msg) => msg.author.id === targetUser.id)
+            .slice(0, amount);
+        } else {
+          messagesToDelete = Array.from(fetchedMessages.values()).slice(
+            0,
+            amount,
+          );
+        }
+
+        if (messagesToDelete.length === 0) {
+          await safelyRespond(
+            interaction,
+            targetUser
+              ? `No messages found from ${targetUser.tag} in the last 100 messages.`
+              : 'No messages found to delete.',
+          );
+          return;
+        }
+      } catch (error) {
+        logger.error('[PurgeCommand] Failed to fetch messages', error);
+        await safelyRespond(
+          interaction,
+          'Failed to fetch messages from this channel.',
+        );
+        return;
+      }
+
+      // Filter messages by age
+      const ageCutoff = Date.now() - ageLimitMs;
+      const deletableMessages = messagesToDelete.filter(
+        (msg) => msg.createdTimestamp > ageCutoff,
+      );
+
+      const tooOldCount = messagesToDelete.length - deletableMessages.length;
+
+      if (deletableMessages.length === 0) {
+        await safelyRespond(
+          interaction,
+          `All selected messages are older than ${ageLimitStr} and cannot be deleted.`,
+        );
+        return;
+      }
+
+      // Perform bulk delete
+      let deletedCount = 0;
+      try {
+        // bulkDelete returns a Collection of deleted messages
+        // filterOld parameter will filter messages older than 14 days automatically
+        const deleted = await guildChannel.bulkDelete(deletableMessages, true);
+        deletedCount = deleted.size;
+      } catch (error) {
+        logger.error('[PurgeCommand] Failed to bulk delete messages', error);
+        await safelyRespond(
+          interaction,
+          'Failed to delete messages. Please try again.',
+        );
+        return;
+      }
+
+      // Log the purge action to audit channel via central logAction
+      try {
+        await logAction({
+          guild,
+          action: 'purge',
+          channel: guildChannel,
+          moderator,
+          deletedMessages: Array.from(deletableMessages.values()).slice(
+            0,
+            deletedCount,
+          ),
+          skippedCount: tooOldCount,
+          targetUser: targetUser ?? undefined,
+          reason,
+          ageLimit: ageLimitStr,
+        } as PurgeLogAction);
+      } catch (error) {
+        logger.error('[PurgeCommand] Failed to log purge action', error);
+      }
+
+      // Track achievement
+      await processCommandAchievements(
+        interaction.user.id,
+        'purge',
+        interaction.guild,
+      );
+
+      // Send success response
+      let responseContent = `Successfully deleted ${deletedCount} message${deletedCount !== 1 ? 's' : ''}`;
+      if (targetUser) {
+        responseContent += ` from ${targetUser.tag}`;
+      }
+      if (tooOldCount > 0) {
+        responseContent += `\n⚠️ ${tooOldCount} message${tooOldCount !== 1 ? 's were' : ' was'} skipped (older than ${ageLimitStr})`;
+      }
+      responseContent += '.';
+
+      await safelyRespond(interaction, responseContent);
+    } catch (error) {
+      logger.error('[PurgeCommand] Error executing purge command', error);
+      await safelyRespond(
+        interaction,
+        'An error occurred while purging messages.',
+      );
+    }
+  },
+};
+
+export default command;

--- a/src/commands/util/help.ts
+++ b/src/commands/util/help.ts
@@ -10,7 +10,11 @@ import {
 
 import type { OptionsCommand } from '@/types/CommandTypes.js';
 import type { ExtendedClient } from '@/structures/ExtendedClient.js';
-import { safeRemoveComponents, safelyRespond } from '@/util/helpers.js';
+import {
+  safeRemoveComponents,
+  safelyRespond,
+  validateInteraction,
+} from '@/util/helpers.js';
 import { logger } from '@/util/logger.js';
 
 const DOC_BASE_URL = 'https://docs.poixpixel.ahmadk953.org/';
@@ -30,6 +34,8 @@ const command: OptionsCommand = {
 
   execute: async (interaction) => {
     if (!interaction.isChatInputCommand() || !interaction.guild) return;
+
+    if (!(await validateInteraction(interaction))) return;
 
     try {
       const client = interaction.client as ExtendedClient;
@@ -123,11 +129,10 @@ const command: OptionsCommand = {
       });
 
       collector.on('collect', async (i) => {
+        if (!(await validateInteraction(i))) return;
+
         if (i.user.id !== interaction.user.id) {
-          await i.reply({
-            content: 'You cannot use this menu.',
-            flags: ['Ephemeral'],
-          });
+          await safelyRespond(i, 'You cannot use this menu.');
           return;
         }
 
@@ -274,6 +279,7 @@ function getCategoryFromCommand(commandName: string): string {
     'recalculate-levels': 'util',
     help: 'util',
     config: 'util',
+    purge: 'util',
 
     'test-join': 'testing',
     'test-leave': 'testing',

--- a/src/util/logging/constants.ts
+++ b/src/util/logging/constants.ts
@@ -14,6 +14,7 @@ export const ACTION_COLORS: Record<LogActionType | 'default', number> = {
   memberLeave: 0xff0000,
   roleDelete: 0xff0000,
   roleRemove: 0xff0000,
+  purge: 0xff0000,
 
   // Warning actions - Orange
   warn: 0xffaa00,
@@ -67,6 +68,7 @@ export const ACTION_EMOJIS: Record<LogActionType, string> = {
   memberNicknameUpdate: '📝',
   roleAdd: '➕',
   roleRemove: '➖',
+  purge: '🗑️',
 };
 
 /**

--- a/src/util/logging/types.ts
+++ b/src/util/logging/types.ts
@@ -27,6 +27,8 @@ export type ModerationActionType =
  * Message log action types
  */
 export type MessageActionType = 'messageDelete' | 'messageEdit';
+// Add purge as message action for structured logging
+export type PurgeActionType = 'purge';
 
 /**
  * Member log action types
@@ -63,6 +65,7 @@ export type LogActionType =
   | MessageActionType
   | MemberActionType
   | RoleActionType
+  | PurgeActionType
   | ChannelActionType;
 
 /**
@@ -105,6 +108,20 @@ export interface MessageLogAction extends BaseLogAction {
   message: Message<true>;
   oldContent?: string;
   newContent?: string;
+}
+
+/**
+ * Purge log action
+ */
+export interface PurgeLogAction extends BaseLogAction {
+  action: 'purge';
+  channel: GuildChannel;
+  moderator: GuildMember;
+  deletedMessages: Message[];
+  skippedCount: number;
+  targetUser?: User;
+  reason: string;
+  ageLimit: string;
 }
 
 /**
@@ -191,4 +208,5 @@ export type LogActionPayload =
   | RoleLogAction
   | RoleCreateDeleteAction
   | RoleUpdateAction
-  | ChannelLogAction;
+  | ChannelLogAction
+  | PurgeLogAction;


### PR DESCRIPTION
# Pull Request

<!-- Thank you for your contribution! Please read CONTRIBUTING.md before submitting. -->

## Summary

This pull request introduces a new `/purge` moderation command for bulk deleting messages in Discord channels, along with comprehensive documentation and audit logging improvements. The changes add the command implementation, update the logging system to support purge actions with detailed logs, and expand type definitions for structured logging. The most important changes are grouped below:

**New Command Implementation and Documentation**

* Added the `/purge` command in `src/commands/moderation/purge.ts` to bulk delete up to 100 messages, with options for age limit, user filtering, and audit logging. Includes robust error handling and achievement tracking.
* Created a detailed documentation file `docs/bot/commands/purge-command.md` describing command usage, features, limitations, audit log format, error handling, and configuration.

**Audit Logging Enhancements**

* Updated the logging system in `src/util/logging/logAction.ts` to handle purge actions: generates a detailed log file of deleted messages, sends it as an attachment to the audit log channel, and cleans up temporary files. Prevents duplicate generic log messages for purge actions. [[1]](diffhunk://#diff-d52b9680b98f9322dff96287331fe0422941b70767cc5353d9121549823380f9R6-R13) [[2]](diffhunk://#diff-d52b9680b98f9322dff96287331fe0422941b70767cc5353d9121549823380f9R48-R50) [[3]](diffhunk://#diff-d52b9680b98f9322dff96287331fe0422941b70767cc5353d9121549823380f9R125-R236) [[4]](diffhunk://#diff-d52b9680b98f9322dff96287331fe0422941b70767cc5353d9121549823380f9R563-R564)
* Added purge-specific color (`0xff0000`) and emoji (`🗑️`) to the logging constants in `src/util/logging/constants.ts` for consistent embed styling. [[1]](diffhunk://#diff-b2fdd515432ceaea2930b08ca9d7dce099d9cfab747e800b3d3294ae611d2ca2R17) [[2]](diffhunk://#diff-b2fdd515432ceaea2930b08ca9d7dce099d9cfab747e800b3d3294ae611d2ca2R71)

**Type System Expansion**

* Extended log action types in `src/util/logging/types.ts` to support purge actions with a new `PurgeLogAction` interface and updated union types for structured payloads. [[1]](diffhunk://#diff-578514deb7c9deeb02b40565c92d42606decaeea126e468be8d356e90eea0ce0R30-R31) [[2]](diffhunk://#diff-578514deb7c9deeb02b40565c92d42606decaeea126e468be8d356e90eea0ce0R68) [[3]](diffhunk://#diff-578514deb7c9deeb02b40565c92d42606decaeea126e468be8d356e90eea0ce0R113-R126) [[4]](diffhunk://#diff-578514deb7c9deeb02b40565c92d42606decaeea126e468be8d356e90eea0ce0L194-R212)

## Related issues

_No related issues_

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no functional changes)
- [ ] docs (documentation only)
- [ ] chore (maintenance, deps)
- [ ] perf (performance)
- [ ] ci (build/CI/CD)

## What changed

- Added a new purge message command
- Added a new audit log event for the purge messages command

## How was this tested?

- [x] Local run: `yarn dev` / `yarn no-deploy`
- [x] Lint: `yarn lint`
- [x] Format: `yarn format: fix`
- [x] Build: `yarn compile`
- [x] Manual verification (describe steps below)

Test notes:

Tested by starting bot and purging messages in a channel using different configurations.

## Database or cache changes

- [x] N/A
- [ ] Schema changed; generated and applied migrations with `drizzle-kit`
- [ ] Data migration required
- [ ] Redis key(s) added/changed (prefix with `bot:`); includes graceful degradation

Details:

## Breaking changes

- [x] No breaking changes
- [ ] Breaking change (describe impact and migration path)

Migration notes:

## Security and privacy

- [x] No new sensitive data handled
- [x] Secrets management unchanged
- [x] Considered abuse/spam vectors for new commands/events

Notes:

## Checklist

- [x] I followed the contribution guidelines in `CONTRIBUTING.md`
- [x] PR title follows Conventional Commits (e.g., `feat(commands/fun): ...`)
- [x] Branch name follows repo convention (e.g., `username/feature-name`)
- [x] Updated docs and examples where needed
- [x] Added or updated telemetry/logging where useful
- [x] For long-running operations, ensured `deferReply()` usage where needed
- [x] For commands, call `processCommandAchievements()` after execution

## Additional context for reviewers

Anything that would help reviewers (design choices, tradeoffs, follow-ups).

<!-- Multiple templates are available in .github/PULL_REQUEST_TEMPLATE/. To prefill with one, use the `template` query parameter when creating a PR. -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new /purge moderation command to bulk delete recent messages with optional age and user filters. Includes detailed audit logging with an attached purge log for transparency.

- **New Features**
  - Added /purge with amount (1–100), age_limit (max 14d), user filter, and reason; validates channel and bot permissions; clear error messages.
  - Audit logs create a detailed purge log file, upload it to the audit channel, then clean up the temp file; prevents duplicate generic logs.
  - Introduced purge-specific logging styling (emoji, color) and a structured PurgeLogAction type.
  - Added command documentation and updated .gitignore to ignore temp/ and .serena/ directories.

<!-- End of auto-generated description by cubic. -->

